### PR TITLE
changing image references from the -slim ones to ones that match the …

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -7,7 +7,7 @@
 #       This is handled in openshift
 #
 
-FROM python:3.12-slim
+FROM registry.redhat.io/ubi9/python-312:latest
 
 USER root
 

--- a/dev-docker/django/Dockerfile
+++ b/dev-docker/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM registry.redhat.io/ubi9/python-312:latest
 
 RUN mkdir /build
 WORKDIR /build

--- a/dev-docker/frontend/Dockerfile
+++ b/dev-docker/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19.0-slim
+FROM registry.redhat.io/ubi9/nodejs-20:latest
 
 # Default to watching
 # Override with:


### PR DESCRIPTION
I changed image references for python and node.js from the -slim ones to ones that match the RedHat UBI9 versions in the infrastructure repository.