### PR TITLE
Update GOV.UK Notify to the latest version

### DIFF
--- a/nsc/notify/tests/test_process_send_receipt.py
+++ b/nsc/notify/tests/test_process_send_receipt.py
@@ -62,7 +62,7 @@ def test_email_object_doesnt_exist_is_not_found(new_status, client, make_email):
             reverse("notify:receipt"),
             expect_errors=True,
             headers={"Authorization": f"bearer {token.token}"},
-            params={"reference": email.id + 1, "status": new_status},
+            data={"reference": email.id + 1, "status": new_status},
         ).status_code
         == 404
     )
@@ -109,9 +109,9 @@ def test_status_is_valid_email_is_updated(new_status, client, make_email):
         reverse("notify:receipt"),
         expect_errors=True,
         headers={"Authorization": f"bearer {token.token}"},
-        data={"reference": email.id, "status": f"{new_status}"},
+        data={"reference": email.id, "status": new_status},
     )
 
-    email.refresh_from_db()
+    updated_email = Email.objects.get(id=email.id)
 
-    assert email.status == new_status
+    assert updated_email.status == new_status

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -94,7 +94,7 @@ markupsafe==2.0.1
 mccabe==0.7.0
 model-bakery==1.20.4
 mypy-extensions==0.4.3
-notifications-python-client==6.3.0
+notifications-python-client==10.0.1
 packaging==25.0
 paramiko==3.4.0
 parso==0.7.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -442,7 +442,7 @@ nltk==3.9.1
     # via
    
     #   safety
-notifications-python-client==6.3.0
+notifications-python-client==10.0.1
     # via
    
     #   -r requirements-dev.in

--- a/requirements.in
+++ b/requirements.in
@@ -91,7 +91,7 @@ model-bakery==1.20.4
 msgpack==1.1.0
 mypy-extensions==0.4.3
 nltk==3.9.1
-notifications-python-client==6.3.0
+notifications-python-client==10.0.1
 packageurl-python==0.16.0
 packaging==25.0
 paramiko==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -347,7 +347,7 @@ nltk==3.9.1
     # via
     #   -r requirements.in
     #   safety
-notifications-python-client==6.3.0
+notifications-python-client==10.0.1
     # via -r requirements.in
 packageurl-python==0.16.0
     # via


### PR DESCRIPTION
Updated notifications-python-client to v10.0.1 (latest):

- Aligned integration with latest GOV.UK Notify API