### PR TITLE
Feature/ip restriction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,4 @@ jobs:
           DATABASE_USER: postgres
           DATABASE_PASSWORD: postgres
           REDIS_SERVICE_HOST: localhost
+          DJANGO_ADMIN_IP_RANGES: "127.0.0.1/32"

--- a/deploy/openshift-template.yaml
+++ b/deploy/openshift-template.yaml
@@ -254,6 +254,11 @@ objects:
                 configMapKeyRef:
                   name: django-webpack
                   key: APP_CONFIG
+            - name: DJANGO_ADMIN_IP_RANGES
+              valueFrom:
+                configMapKeyRef:
+                  name: django-webpack
+                  key: DJANGO_ADMIN_IP_RANGES
             - name: DJANGO_CONFIG_DIR
               value: "/run/configs/common"
             - name: DJANGO_SECRET_DIR

--- a/nsc/middleware/ip_restriction.py
+++ b/nsc/middleware/ip_restriction.py
@@ -1,0 +1,52 @@
+from django.http import HttpResponseForbidden
+from django.conf import settings
+import ipaddress
+import logging
+
+logger = logging.getLogger(__name__)
+
+class AdminIPRestrictionMiddleware:
+    """
+    Middleware to restrict access to Django admin endpoints based on allowed IP ranges.
+
+    The allowed IP ranges are read from the DJANGO_ADMIN_IP_RANGES environment variable,
+    which should be a comma-separated list of CIDR ranges (e.g. "1.2.3.4/32, 5.6.7.8/24").
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        raw_ip_ranges = settings.DJANGO_ADMIN_IP_RANGES.strip()
+        if not raw_ip_ranges:
+            raise RuntimeError("ALLOWED_ADMIN_IPS environment variable is not set or empty")
+        raw_ip_list = raw_ip_ranges.split(",")
+        stripped_ips = [raw_ip.strip() for raw_ip in raw_ip_list if raw_ip.strip()]
+        # Converting the strings into IPv4Network objects
+        self.allowed_ips = [ipaddress.ip_network(stripped_ip) for stripped_ip in stripped_ips]
+
+    def __call__(self, request):
+        admin_prefixes = ["/django-admin/", "/admin/"]
+        if any(request.path.startswith(prefix) for prefix in admin_prefixes):
+            ip = self.get_incoming_ip(request)
+            logger.info(f"User attempted to access {request.path} from IP: {ip}")
+            if not self.is_allowed_ip(ip):
+                logger.warning(f"403 Forbidden: IP {ip} not allowed to access django-admin.")
+                return HttpResponseForbidden(f"403 Forbidden: IP not allowed.")
+            logger.info(f"Access to django-admin granted for IP: {ip}")
+        return self.get_response(request)
+    
+    def is_allowed_ip(self, ip):
+        try:
+            incoming_ip = ipaddress.ip_address(ip)
+            return any (incoming_ip in allowed_range for allowed_range in self.allowed_ips)
+        except ValueError:
+            logger.error(f"Invalid IP address format: {ip}")
+            return False
+        
+    def get_incoming_ip(self, request):
+        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+        logger.debug(f"X-Forwarded-For header: {x_forwarded_for}")
+        if x_forwarded_for:
+            return x_forwarded_for.split(",")[0].strip()
+        fallback_ip = request.META.get("REMOTE_ADDR", "")
+        logger.debug(f"X-Forwarded-For not found. Using REMOTE_ADDR: {fallback_ip}")
+        return fallback_ip

--- a/nsc/middleware/ip_restriction.py
+++ b/nsc/middleware/ip_restriction.py
@@ -17,7 +17,7 @@ class AdminIPRestrictionMiddleware:
         self.get_response = get_response
         raw_ip_ranges = settings.DJANGO_ADMIN_IP_RANGES.strip()
         if not raw_ip_ranges:
-            raise RuntimeError("ALLOWED_ADMIN_IPS environment variable is not set or empty")
+            raise RuntimeError("DJANGO_ADMIN_IP_RANGES environment variable is not set or empty")
         raw_ip_list = raw_ip_ranges.split(",")
         stripped_ips = [raw_ip.strip() for raw_ip in raw_ip_list if raw_ip.strip()]
         # Converting the strings into IPv4Network objects

--- a/nsc/middleware/redirection.py
+++ b/nsc/middleware/redirection.py
@@ -8,7 +8,7 @@ def redirect_url_fragment(get_response):
     Sets the fragment of the redirect urls
     """
 
-    def middleware(request):
+    def redirection(request):
         response = get_response(request)
 
         if (
@@ -19,4 +19,4 @@ def redirect_url_fragment(get_response):
 
         return response
 
-    return middleware
+    return redirection

--- a/nsc/settings.py
+++ b/nsc/settings.py
@@ -135,9 +135,12 @@ class Common(Configuration):
     # SECURITY WARNING: don't run with debug turned on in production!
     DEBUG = True
 
-    # Comma separated list of hosts; for exmaple:
+    # Comma separated list of hosts; for example:
     #   DJANGO_ALLOWED_HOSTS=host1.example.com,host2.example.com
     ALLOWED_HOSTS = get_env("DJANGO_ALLOWED_HOSTS", cast=csv_to_list, default=["*"])
+
+    # String containing ip ranges allowed to access django-admin
+    DJANGO_ADMIN_IP_RANGES = get_env("DJANGO_ADMIN_IP_RANGES", default="")
 
     INSTALLED_APPS = [
         "django.contrib.admin",
@@ -174,10 +177,11 @@ class Common(Configuration):
         "django.middleware.cache.FetchFromCacheMiddleware",
         "django.middleware.csrf.CsrfViewMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "nsc.middleware.ip_restriction.AdminIPRestrictionMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
         "simple_history.middleware.HistoryRequestMiddleware",
-        "nsc.middleware.redirect_url_fragment",
+        "nsc.middleware.redirection.redirect_url_fragment",
         "nsc.user.middleware.record_user_session",
     ]
 


### PR DESCRIPTION
Added a feature which allows for the IP restriction of the /django-admin and /admin endpoints. 

The IP ranges which allow for access to these pages are defined in the django-webpack ConfigMap on OpenShift. 

To run this locally, add the following (string type) variable:
DJANGO_ADMIN_IP_RANGES: "0.0.0.0/32, W.X.Y.0/ZZ "

...in the dev-docker-compose.yaml, where 0.0.0.0/32 is a dummy placeholder and W.X.Y.0/ZZ represents the custom IP you want to restrict these pages to and shows the correct format. Note that the last digit before the / must be set to 0 like above to avoid a "host bits set" error.