### PR TITLE
Upgrading the HSTS policy 

### DIFF
--- a/nsc/settings.py
+++ b/nsc/settings.py
@@ -599,7 +599,10 @@ class Deployed(Build):
     SECURE_REFERRER_POLICY = "same-origin"
 
     # Sets HTTP Strict Transport Security header on all responses.
-    SECURE_HSTS_SECONDS = 3600  # Seconds
+    SECURE_HSTS_SECONDS = 31536000 # Seconds
+
+    # Include subdomains in HSTS policy
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 
     # Sets up treating connections from the load balancer as secure
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")


### PR DESCRIPTION
Lengthening HSTS policy duration to 1 year and including subdomains in the HSTS policy.

It will now last for 1 year and also cover subdomains. 

"SECURE_HSTS_PRELOAD = True" was already present and this has been left the same.

SECURE_SSL_REDIRECT has **not** been set to true as this is handled by OpenShift already - I verified this by verifying that OpenShift routes have TLS enabled which makes means OpenShift handles HTTPS and HTTP-to-HTTPS redirection at the router.

The code on this "feature/hsts-header" branch has already been tested and verified in the development environment.