### PR TITLE
Reinstate GOV.UK Notify email functionality across all environments 

### DIFF
--- a/nsc/settings.py
+++ b/nsc/settings.py
@@ -509,24 +509,20 @@ class Dev(Webpack, Common):
     PHE_COMMUNICATIONS_NAME = "PHE Comms"
     PHE_HELP_DESK_EMAIL = "phehelpdesk@example.com"
     CONSULTATION_COMMENT_ADDRESS = "phecomments@example.com"
-    NOTIFY_SERVICE_ENABLED = False
-    NOTIFY_SERVICE_API_KEY = None
-    NOTIFY_TEMPLATE_CONSULTATION_OPEN = "consultation-open-templates"
-    NOTIFY_TEMPLATE_CONSULTATION_OPEN_COMMS = "comms-consultation-open-templates"
-    NOTIFY_TEMPLATE_SUBSCRIBER_CONSULTATION_OPEN = (
-        "subscriber-consultation-open-template"
-    )
-    NOTIFY_TEMPLATE_DECISION_PUBLISHED = "decision-published-template"
-    NOTIFY_TEMPLATE_SUBSCRIBER_DECISION_PUBLISHED = (
-        "subscriber-decision-published-template"
-    )
-    NOTIFY_TEMPLATE_PUBLIC_COMMENT = "public-comment-template"
-    NOTIFY_TEMPLATE_STAKEHOLDER_COMMENT = "stakeholder-comment-template"
-    NOTIFY_TEMPLATE_SUBSCRIBED = "subscribed-template"
-    NOTIFY_TEMPLATE_UPDATED_SUBSCRIPTION = "updated-subscription-template"
-    NOTIFY_TEMPLATE_UNSUBSCRIBE = "unsubscribed-template"
-    NOTIFY_TEMPLATE_HELP_DESK = "help-desk-template"
-    NOTIFY_TEMPLATE_HELP_DESK_CONFIRMATION = "help-desk-confirmation-template"
+    NOTIFY_SERVICE_ENABLED = True
+    NOTIFY_SERVICE_API_KEY = "nsc_development-04e9cfec-122d-4464-8836-b727424bb10c-7e2f1fee-8d84-445c-87d1-f9cd0289cd34"
+    NOTIFY_TEMPLATE_CONSULTATION_OPEN = "b2dc7cc0-c2ee-4cd6-8245-e400d8154ffb"
+    NOTIFY_TEMPLATE_CONSULTATION_OPEN_COMMS = "18d25b7f-ea13-42b4-ab2b-e6eb00f0171d"
+    NOTIFY_TEMPLATE_SUBSCRIBER_CONSULTATION_OPEN = "18d25b7f-ea13-42b4-ab2b-e6eb00f0171d"
+    NOTIFY_TEMPLATE_DECISION_PUBLISHED = "0698a56f-0d57-4467-86ab-2a931ff578d9"
+    NOTIFY_TEMPLATE_SUBSCRIBER_DECISION_PUBLISHED = "9e5685d2-ace5-4359-998a-d55dee05a198"
+    NOTIFY_TEMPLATE_PUBLIC_COMMENT = "24a18541-19a1-4395-b175-29ba393bf336"
+    NOTIFY_TEMPLATE_STAKEHOLDER_COMMENT = "191e9b98-9efb-4105-9821-477b1e5d66d2"
+    NOTIFY_TEMPLATE_SUBSCRIBED = "6e8b2e36-b3db-4e30-a070-746e07b6578c"
+    NOTIFY_TEMPLATE_UPDATED_SUBSCRIPTION = "7cd7b0bd-5a37-48c1-b7bb-7ce4b9c1809e"
+    NOTIFY_TEMPLATE_UNSUBSCRIBE = "35041ec3-3568-43ee-a18b-c21d3d1a902e"
+    NOTIFY_TEMPLATE_HELP_DESK = "35e6fe74-d5e2-4bd6-8462-37e65abdaeea"
+    NOTIFY_TEMPLATE_HELP_DESK_CONFIRMATION = "9a3bf35f-242f-46bd-8381-0685d547d06e"
 
     @property
     def INSTALLED_APPS(self):
@@ -724,11 +720,19 @@ class Deployed(Build):
 
 
 class Stage(Deployed):
-    pass
+    """
+    Staging environment settings
+    """
+    # Enable notify service for staging
+    NOTIFY_SERVICE_ENABLED = True
 
 
 class Prod(Deployed):
-    pass
+    """
+    Production environment settings  
+    """
+    # Enable notify service for production
+    NOTIFY_SERVICE_ENABLED = True
 
 
 class Demo(Build):

--- a/nsc/settings.py
+++ b/nsc/settings.py
@@ -513,9 +513,13 @@ class Dev(Webpack, Common):
     NOTIFY_SERVICE_API_KEY = "nsc_development-04e9cfec-122d-4464-8836-b727424bb10c-7e2f1fee-8d84-445c-87d1-f9cd0289cd34"
     NOTIFY_TEMPLATE_CONSULTATION_OPEN = "b2dc7cc0-c2ee-4cd6-8245-e400d8154ffb"
     NOTIFY_TEMPLATE_CONSULTATION_OPEN_COMMS = "18d25b7f-ea13-42b4-ab2b-e6eb00f0171d"
-    NOTIFY_TEMPLATE_SUBSCRIBER_CONSULTATION_OPEN = "18d25b7f-ea13-42b4-ab2b-e6eb00f0171d"
+    NOTIFY_TEMPLATE_SUBSCRIBER_CONSULTATION_OPEN = (
+        "18d25b7f-ea13-42b4-ab2b-e6eb00f0171d"
+    )
     NOTIFY_TEMPLATE_DECISION_PUBLISHED = "0698a56f-0d57-4467-86ab-2a931ff578d9"
-    NOTIFY_TEMPLATE_SUBSCRIBER_DECISION_PUBLISHED = "9e5685d2-ace5-4359-998a-d55dee05a198"
+    NOTIFY_TEMPLATE_SUBSCRIBER_DECISION_PUBLISHED = (
+        "9e5685d2-ace5-4359-998a-d55dee05a198"
+    )
     NOTIFY_TEMPLATE_PUBLIC_COMMENT = "24a18541-19a1-4395-b175-29ba393bf336"
     NOTIFY_TEMPLATE_STAKEHOLDER_COMMENT = "191e9b98-9efb-4105-9821-477b1e5d66d2"
     NOTIFY_TEMPLATE_SUBSCRIBED = "6e8b2e36-b3db-4e30-a070-746e07b6578c"
@@ -723,14 +727,16 @@ class Stage(Deployed):
     """
     Staging environment settings
     """
+
     # Enable notify service for staging
     NOTIFY_SERVICE_ENABLED = True
 
 
 class Prod(Deployed):
     """
-    Production environment settings  
+    Production environment settings
     """
+
     # Enable notify service for production
     NOTIFY_SERVICE_ENABLED = True
 


### PR DESCRIPTION
The GOV.UK Notify email system was completely disabled across all environments. While the email infrastructure was built and functional, emails were never actually sent due to:

**Problem:**
- NOTIFY_SERVICE_ENABLED = False acting as a feature flag
- Placeholder template IDs instead of real GOV.UK Notify UUIDs
- Outdated API key configuration

**Solution:**
This PR reinstates the complete email functionality by :

Configuration Changes:
- Enable email service: Set NOTIFY_SERVICE_ENABLED = True for Dev, Stage, and Prod environments
- Real template IDs: Replace placeholder strings with actual GOV.UK Notify template UUIDs
- Updated API key: development key for local testing

Email Types Restored:
- Subscription confirmations (NOTIFY_TEMPLATE_SUBSCRIBED)
- Consultation notifications (NOTIFY_TEMPLATE_CONSULTATION_OPEN)
- Decision published alerts (NOTIFY_TEMPLATE_DECISION_PUBLISHED)
- Help desk emails (NOTIFY_TEMPLATE_HELP_DESK)
- Comment confirmations (public & stakeholder)
- Unsubscribe confirmations

Technical Details:
- File changed: nsc/settings.py 
- Environments affected: Dev (immediate), Stage/Prod (requires ops team env var setup)
- Security: Production environments still use environment variables for secrets
