### PR TITLE
Rate limiting to prevent spam attacks

### DIFF
--- a/nsc/condition/views.py
+++ b/nsc/condition/views.py
@@ -1,7 +1,9 @@
 from django.conf import settings
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.views.generic import DetailView, FormView, ListView, TemplateView
+from django_ratelimit.decorators import ratelimit
 
 from nsc.notify.models import Email
 from nsc.policy.models import Policy
@@ -80,6 +82,8 @@ class ConsultationView(ConsultationMixin, TemplateView):
         )
 
 
+@method_decorator(ratelimit(key='ip', rate='5/h', method='POST', block=True), name='post')
+@method_decorator(ratelimit(key='header:x-forwarded-for', rate='5/h', method='POST', block=True), name='post')
 class PublicCommentView(ConsultationMixin, FormView):
     template_name = "policy/public/public_comment.html"
     form_class = PublicCommentForm
@@ -158,6 +162,8 @@ class PublicCommentSubmittedView(ConsultationMixin, TemplateView):
         )
 
 
+@method_decorator(ratelimit(key='ip', rate='5/h', method='POST', block=True), name='post')
+@method_decorator(ratelimit(key='header:x-forwarded-for', rate='5/h', method='POST', block=True), name='post')
 class StakeholderCommentView(ConsultationMixin, FormView):
     template_name = "policy/public/stakeholder_comment.html"
     form_class = StakeholderCommentForm

--- a/nsc/settings.py
+++ b/nsc/settings.py
@@ -227,7 +227,12 @@ class Common(Configuration):
             }
         }
 
-    CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://redis:6379/1",
+        }
+    }
 
     # Password validation
     # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
@@ -357,6 +362,9 @@ class Common(Configuration):
         "tracking", "gtm-property-id", required=False, default=None
     )
     HOTJAR_ID = get_secret("tracking", "hotjar-id", required=False, default=None)
+
+    # Rate limiting settings
+    RATELIMIT_USE_CACHE = "default"
 
     # Settings for celery
     CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/0"  # noqa

--- a/nsc/subscription/views.py
+++ b/nsc/subscription/views.py
@@ -4,7 +4,9 @@ from django.conf import settings
 from django.db import transaction
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse, reverse_lazy
+from django.utils.decorators import method_decorator
 from django.views import generic
+from django_ratelimit.decorators import ratelimit
 
 from ..notify.models import Email
 from .forms import (
@@ -31,6 +33,8 @@ class SubscriptionLanding(generic.TemplateView):
     template_name = "subscription/subscription_landing.html"
 
 
+@method_decorator(ratelimit(key='ip', rate='5/h', method='POST', block=True), name='post')
+@method_decorator(ratelimit(key='header:x-forwarded-for', rate='5/h', method='POST', block=True), name='post')
 class PublicSubscriptionStart(generic.FormView):
     form_class = SubscriptionStart
     template_name = "subscription/public_subscription_management_form.html"
@@ -61,6 +65,8 @@ class PublicSubscriptionStart(generic.FormView):
             return self.render_to_response(self.get_context_data(form=form))
 
 
+@method_decorator(ratelimit(key='ip', rate='5/h', method='POST', block=True), name='post')
+@method_decorator(ratelimit(key='header:x-forwarded-for', rate='5/h', method='POST', block=True), name='post')
 class PublicSubscriptionManage(GetObjectFromTokenMixin, generic.UpdateView):
     model = Subscription
     form_class = ManageSubscriptionsForm
@@ -111,6 +117,8 @@ class PublicSubscriptionManage(GetObjectFromTokenMixin, generic.UpdateView):
             return self.render_to_response(self.get_context_data(form=form))
 
 
+@method_decorator(ratelimit(key='ip', rate='5/h', method='POST', block=True), name='post')
+@method_decorator(ratelimit(key='header:x-forwarded-for', rate='5/h', method='POST', block=True), name='post')
 class PublicSubscriptionEmails(generic.UpdateView):
     model = Subscription
     form_class = CreateSubscriptionForm
@@ -163,6 +171,8 @@ class PublicSubscriptionComplete(GetObjectFromTokenMixin, generic.DetailView):
     template_name = "subscription/public_subscription_complete.html"
 
 
+@method_decorator(ratelimit(key='ip', rate='5/h', method='POST', block=True), name='post')
+@method_decorator(ratelimit(key='header:x-forwarded-for', rate='5/h', method='POST', block=True), name='post')
 class StakeholderSubscriptionStart(generic.CreateView):
     model = StakeholderSubscription
     template_name = "subscription/stakeholder_subscription_creation.html"

--- a/nsc/support/views.py
+++ b/nsc/support/views.py
@@ -1,12 +1,16 @@
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.views import generic
+from django_ratelimit.decorators import ratelimit
 
 from ..notify.models import Email
 from .forms import ContactForm
 
 
+@method_decorator(ratelimit(key='ip', rate='3/h', method='POST', block=True), name='post')
+@method_decorator(ratelimit(key='header:x-forwarded-for', rate='3/h', method='POST', block=True), name='post')
 class ContactHelpDesk(generic.FormView):
     form_class = ContactForm
     template_name = "support/contact_help_desk.html"

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -66,6 +66,7 @@ django-extensions==3.1.5
 django-filter==25.1
 django-model-utils==5.0.0
 django-redis==5.2.0
+django-ratelimit==4.1.0
 django-simple-history==3.0.0
 django-storages==1.14.2
 doc8==0.11.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -238,6 +238,10 @@ django-redis==5.2.0
     # via
    
     #   -r requirements-dev.in
+django-ratelimit==4.1.0
+    # via
+   
+    #   -r requirements-dev.in
 django-simple-history==3.0.0
     # via
    

--- a/requirements.in
+++ b/requirements.in
@@ -46,6 +46,7 @@ django-extensions==3.1.5
 django-filter==25.1
 django-model-utils==5.0.0
 django-redis==5.2.0
+django-ratelimit==4.1.0
 django-simple-history==3.0.0
 django-storages==1.14.2
 django-webtest==1.9.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -188,6 +188,8 @@ django-model-utils==5.0.0
     # via -r requirements.in
 django-redis==5.2.0
     # via -r requirements.in
+django-ratelimit==4.1.0
+    # via -r requirements.in
 django-simple-history==3.0.0
     # via -r requirements.in
 django-storages==1.14.2


### PR DESCRIPTION
- Add django-ratelimit==4.1.0 dependency
- Configure Redis cache for rate limit storage
- Apply rate limiting to all public forms:
  * Contact forms: 3 submissions/hour per IP
  * Comment forms: 5 submissions/hour per IP
  * Subscription forms: 5 submissions/hour per IP
- Use Django default 403 error handling