### PR TITLE
Hidden field

### DIFF
--- a/nsc/condition/forms.py
+++ b/nsc/condition/forms.py
@@ -1,9 +1,10 @@
 from django import forms
 from django.forms import HiddenInput
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 
 from model_utils import Choices
 
+from nsc.mixins.formmixin import BaseMixin
 from nsc.policy.models import Policy
 
 
@@ -42,7 +43,7 @@ class SearchForm(forms.Form):
     )
 
 
-class PublicCommentForm(forms.Form):
+class PublicCommentForm(BaseMixin, forms.Form):
     COMMENT_FIELDS = {
         "comment_affected": "Please tell us if this condition has affected you, your family or your friends?",
         "comment_evidence": "Do you have any comments on the evidence considered by the UK NSC in the review? "
@@ -102,8 +103,7 @@ class PublicCommentForm(forms.Form):
         return cleaned_data
 
 
-class StakeholderCommentForm(forms.Form):
-
+class StakeholderCommentForm(BaseMixin, forms.Form):
     name = forms.CharField(
         label=_("Full name"), error_messages={"required": _("Enter your full name.")}
     )

--- a/nsc/mixins/formmixin.py
+++ b/nsc/mixins/formmixin.py
@@ -1,7 +1,7 @@
 from django import forms
 
 
-class BaseMixin(forms.Form):
+class BaseMixin:
     backup_email = forms.CharField(
         required=False,
         widget=forms.TextInput(attrs={"style": "display:none", "tabindex": "-1"}),

--- a/nsc/mixins/formmixin.py
+++ b/nsc/mixins/formmixin.py
@@ -1,0 +1,14 @@
+from django import forms
+
+
+class BaseMixin(forms.Form):
+    backup_email = forms.CharField(
+        required=False,
+        widget=forms.TextInput(attrs={"style": "display:none", "tabindex": "-1"}),
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data.get("backup_email"):
+            raise forms.ValidationError("Invalid email address")
+        return cleaned_data

--- a/nsc/subscription/forms.py
+++ b/nsc/subscription/forms.py
@@ -5,6 +5,8 @@ from django.core.paginator import EmptyPage, Paginator
 from django.forms.forms import DeclarativeFieldsMetaclass
 from django.utils.translation import gettext_lazy as _
 
+from nsc.mixins.formmixin import BaseMixin
+
 from ..policy.filters import SearchFilter
 from ..policy.models import Policy
 from .models import StakeholderSubscription, Subscription
@@ -103,7 +105,7 @@ class SubscriptionStart(SubscriptionPolicySearchFormMixin, forms.Form):
     pass
 
 
-class CreateSubscriptionForm(forms.ModelForm):
+class CreateSubscriptionForm(BaseMixin, forms.ModelForm):
     email_confirmation = forms.EmailField(
         label=_("Please confirm your email address"),
         error_messages={"required": _("Confirm your email address")},
@@ -173,3 +175,7 @@ class CreateStakeholderSubscriptionForm(forms.ModelForm):
             )
 
         return cleaned_data
+
+
+class SubscriptionForm(BaseMixin, forms.Form):
+    pass

--- a/nsc/subscription/forms.py
+++ b/nsc/subscription/forms.py
@@ -179,4 +179,3 @@ class CreateStakeholderSubscriptionForm(forms.ModelForm):
 
 class SubscriptionForm(BaseMixin, forms.Form):
     pass
-

--- a/nsc/subscription/forms.py
+++ b/nsc/subscription/forms.py
@@ -179,3 +179,4 @@ class CreateStakeholderSubscriptionForm(forms.ModelForm):
 
 class SubscriptionForm(BaseMixin, forms.Form):
     pass
+

--- a/nsc/support/forms.py
+++ b/nsc/support/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
+
 from nsc.mixins.formmixin import BaseMixin
 
 

--- a/nsc/support/forms.py
+++ b/nsc/support/forms.py
@@ -1,8 +1,9 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
+from nsc.mixins.formmixin import BaseMixin
 
 
-class ContactForm(forms.Form):
+class ContactForm(BaseMixin, forms.Form):
     name = forms.CharField(
         max_length=255, error_messages={"required": _("Enter your name")}
     )

--- a/templates/policy/public/public_comment.html
+++ b/templates/policy/public/public_comment.html
@@ -42,6 +42,10 @@
   <form method="post">
     {% csrf_token %}
 
+    <div style="display:none">
+      <input type="text" name="backup_email" value="">
+    </div>
+
     {% for hidden in form.hidden_fields %}
       {{ hidden }}
     {% endfor %}

--- a/templates/policy/public/stakeholder_comment.html
+++ b/templates/policy/public/stakeholder_comment.html
@@ -37,6 +37,10 @@
   <form method="post">
     {% csrf_token %}
 
+    <div style="display:none">
+      <input type="text" name="backup_email" value="">
+    </div>
+
     {% for hidden in form.hidden_fields %}
       {{ hidden }}
     {% endfor %}

--- a/templates/subscription/public_subscription_email_form.html
+++ b/templates/subscription/public_subscription_email_form.html
@@ -39,6 +39,10 @@
   <form method="post">
     {% csrf_token %}
 
+    <div style="display:none">
+      <input type="text" name="backup_email" value="">
+    </div>
+
     {% if form.errors %}
       {% include "widgets/error_summary.html" %}
     {% endif %}

--- a/templates/support/contact_help_desk.html
+++ b/templates/support/contact_help_desk.html
@@ -8,11 +8,7 @@
 {% endblock %}
 
 {% block content %}
-  <div style="display:none">
-    <input type="text" name="backup_email" value="">
-  </div>
-
-  <p class="govuk-body">
+    <p class="govuk-body">
     {% blocktrans %}
       <a class="govuk-link" href="https://www.gov.uk/government/organisations/uk-national-screening-committee/about">The UK National Screening Committee</a>
       (UK NSC) makes recommendations on all aspects of population screening  in the UK. See the

--- a/templates/support/contact_help_desk.html
+++ b/templates/support/contact_help_desk.html
@@ -8,6 +8,16 @@
 {% endblock %}
 
 {% block content %}
+  {% if request.GET.show_hidden %}
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Test Mode</span>
+        Test Mode Active - Hidden field is now visible
+      </strong>
+    </div>
+  {% endif %}
+
   <p class="govuk-body">
     {% blocktrans %}
       <a class="govuk-link" href="https://www.gov.uk/government/organisations/uk-national-screening-committee/about">The UK National Screening Committee</a>
@@ -39,6 +49,10 @@
 
   <form method="post">
     {% csrf_token %}
+
+    <div style="display:none">
+      <input type="text" name="backup_email" value="">
+    </div>
 
     {% include "widgets/text_input.html" with field=form.name %}
     {% include "widgets/text_input.html" with field=form.organisation %}

--- a/templates/support/contact_help_desk.html
+++ b/templates/support/contact_help_desk.html
@@ -8,15 +8,9 @@
 {% endblock %}
 
 {% block content %}
-  {% if request.GET.show_hidden %}
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Test Mode</span>
-        Test Mode Active - Hidden field is now visible
-      </strong>
-    </div>
-  {% endif %}
+  <div style="display:none">
+    <input type="text" name="backup_email" value="">
+  </div>
 
   <p class="govuk-body">
     {% blocktrans %}


### PR DESCRIPTION
Add honeypot field to public-facing forms for spam protection:

- Implement honeypot field named 'backup_email' in BaseMixin
- Apply to public forms:
  - Public comment form
  - Stakeholder comment form
  - Public subscription form
  - Public help desk form
  
- Hidden field with empty value and display: none style