### PR TITLE
 Consultation email fix

### DIFF
--- a/nsc/policy/models.py
+++ b/nsc/policy/models.py
@@ -218,9 +218,8 @@ class Policy(TimeStampedModel):
 
     def get_email_context(self, **extra):
         return {
-            "policy url": urljoin(settings.EMAIL_ROOT_DOMAIN, self.get_public_url()),
+            "policy url": f"* [{self.name}]({urljoin(settings.EMAIL_ROOT_DOMAIN, self.get_public_url())})",
             "policy": self.name,
-            "policy list": f"* [{self.name}]({urljoin(settings.EMAIL_ROOT_DOMAIN, self.get_public_url())})",
             **extra,
         }
 

--- a/nsc/policy/models.py
+++ b/nsc/policy/models.py
@@ -220,6 +220,7 @@ class Policy(TimeStampedModel):
         return {
             "policy url": urljoin(settings.EMAIL_ROOT_DOMAIN, self.get_public_url()),
             "policy": self.name,
+            "policy list": f"* [{self.name}]({urljoin(settings.EMAIL_ROOT_DOMAIN, self.get_public_url())})",
             **extra,
         }
 


### PR DESCRIPTION
Add clickable policy links in subscriber consultation emails:

Updated the `get_email_context` method in Policy model to include clickable policy links in the `policy_list` parameter